### PR TITLE
Fix/shell script path env

### DIFF
--- a/src/aidd/tools/code_execution.py
+++ b/src/aidd/tools/code_execution.py
@@ -252,10 +252,7 @@ async def execute_shell_script_in_temp_file(script: str, timeout: int) -> tuple[
         try:
             path_env = get_comprehensive_shell_paths()
             env = os.environ.copy()
-            with open("tmp.txt", "a") as f:
-                f.write(path_env)
             env["PATH"] = path_env
-            print(path_env)
             result = subprocess.run(
                 ["/bin/sh", temp_file],  # Use sh explicitly for consistent behavior
                 capture_output=True,

--- a/src/aidd/tools/code_execution.py
+++ b/src/aidd/tools/code_execution.py
@@ -2,48 +2,27 @@ import os
 import stat
 import subprocess
 from typing import Any, Dict, List
-
 import mcp.types as types
+from pathlib import Path
 
 from .state import state
 
 # Language configurations
 LANGUAGE_CONFIGS = {
-    'python': {
-        'file_extension': '.py',
-        'command': ['python3'],
-        'comment_prefix': '#'
+    "python": {"file_extension": ".py", "command": ["python3"], "comment_prefix": "#"},
+    "javascript": {"file_extension": ".js", "command": ["node"], "comment_prefix": "//"},
+    "ruby": {"file_extension": ".rb", "command": ["ruby"], "comment_prefix": "#"},
+    "php": {"file_extension": ".php", "command": ["php"], "comment_prefix": "//"},
+    "go": {"file_extension": ".go", "command": ["go", "run"], "comment_prefix": "//", "wrapper_start": "package main\nfunc main() {", "wrapper_end": "}"},
+    "rust": {
+        "file_extension": ".rs",
+        "command": ["rustc", "-o"],  # Special handling needed
+        "comment_prefix": "//",
+        "wrapper_start": "fn main() {",
+        "wrapper_end": "}",
     },
-    'javascript': {
-        'file_extension': '.js',
-        'command': ['node'],
-        'comment_prefix': '//'
-    },
-    'ruby': {
-        'file_extension': '.rb',
-        'command': ['ruby'],
-        'comment_prefix': '#'
-    },
-    'php': {
-        'file_extension': '.php',
-        'command': ['php'],
-        'comment_prefix': '//'
-    },
-    'go': {
-        'file_extension': '.go',
-        'command': ['go', 'run'],
-        'comment_prefix': '//',
-        'wrapper_start': 'package main\nfunc main() {',
-        'wrapper_end': '}'
-    },
-    'rust': {
-        'file_extension': '.rs',
-        'command': ['rustc', '-o'],  # Special handling needed
-        'comment_prefix': '//',
-        'wrapper_start': 'fn main() {',
-        'wrapper_end': '}'
-    }
 }
+
 
 def execute_code_tool() -> Dict[str, Any]:
     return {
@@ -70,28 +49,30 @@ def execute_code_tool() -> Dict[str, Any]:
                 "language": {
                     "type": "string",
                     "enum": list(LANGUAGE_CONFIGS.keys()),
-                    "description": "Programming language to use. Must be one of the supported languages: " + ", ".join(LANGUAGE_CONFIGS.keys()) + ". " +
-                    "Each language requires the appropriate runtime to be installed on the user's machine. The code will be executed using: python3 for " +
-                    "Python, node for JavaScript, ruby for Ruby, php for PHP, go run for Go, and rustc for Rust."
+                    "description": "Programming language to use. Must be one of the supported languages: "
+                    + ", ".join(LANGUAGE_CONFIGS.keys())
+                    + ". "
+                    + "Each language requires the appropriate runtime to be installed on the user's machine. The code will be executed using: python3 for "
+                    + "Python, node for JavaScript, ruby for Ruby, php for PHP, go run for Go, and rustc for Rust.",
                 },
                 "code": {
                     "type": "string",
-                    "description": "Code to execute on the user's local machine in the current working directory. The code will be saved to a " +
-                    "temporary file and executed within the allowed workspace. For Go and Rust, main function wrappers will be added automatically if " +
-                    "not present. For PHP, <?php will be prepended if not present."
+                    "description": "Code to execute on the user's local machine in the current working directory. The code will be saved to a "
+                    + "temporary file and executed within the allowed workspace. For Go and Rust, main function wrappers will be added automatically if "
+                    + "not present. For PHP, <?php will be prepended if not present.",
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Maximum execution time in seconds. The execution will be terminated if it exceeds this time limit, returning a " +
-                    "timeout message. Must be between 1 and 30 seconds.",
+                    "description": "Maximum execution time in seconds. The execution will be terminated if it exceeds this time limit, returning a " + "timeout message. Must be between 1 and 30 seconds.",
                     "default": 5,
                     "minimum": 1,
-                    "maximum": 30
-                }
+                    "maximum": 30,
+                },
             },
-            "required": ["language", "code"]
-        }
+            "required": ["language", "code"],
+        },
     }
+
 
 def execute_shell_script_tool() -> Dict[str, Any]:
     return {
@@ -122,46 +103,45 @@ def execute_shell_script_tool() -> Dict[str, Any]:
                 "script": {
                     "type": "string",
                     "description": "Shell script to execute on the user's local machine. Can include any valid shell commands or scripts that would "
-                    "run in a standard shell environment. The script is executed using /bin/sh for maximum compatibility across systems."
+                    "run in a standard shell environment. The script is executed using /bin/sh for maximum compatibility across systems.",
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Maximum execution time in seconds. The execution will be terminated if it exceeds this time limit. "
-                    "Default is 300 seconds (5 minutes), with a maximum allowed value of 600 seconds (10 minutes).",
+                    "description": "Maximum execution time in seconds. The execution will be terminated if it exceeds this time limit. Default is 300 seconds (5 minutes), with a maximum allowed value of 600 seconds (10 minutes).",
                     "default": 300,
-                    "maximum": 600
-                }
+                    "maximum": 600,
+                },
             },
-            "required": ["script"]
-        }
+            "required": ["script"],
+        },
     }
+
 
 def is_command_available(command: str) -> bool:
     """Check if a command is available in the system."""
     try:
-        subprocess.run(['which', command],
-                     stdout=subprocess.PIPE,
-                     stderr=subprocess.PIPE,
-                     check=True)
+        subprocess.run(["which", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         return True
     except subprocess.CalledProcessError:
         return False
+
 
 def prepare_code(code: str, language: str) -> str:
     """Prepare code for execution based on language requirements."""
     config = LANGUAGE_CONFIGS[language]
 
-    if language == 'go':
-        if 'package main' not in code and 'func main()' not in code:
+    if language == "go":
+        if "package main" not in code and "func main()" not in code:
             return f"{config['wrapper_start']}\n{code}\n{config['wrapper_end']}"
-    elif language == 'rust':
-        if 'fn main()' not in code:
+    elif language == "rust":
+        if "fn main()" not in code:
             return f"{config['wrapper_start']}\n{code}\n{config['wrapper_end']}"
-    elif language == 'php':
-        if '<?php' not in code:
+    elif language == "php":
+        if "<?php" not in code:
             return f"<?php\n{code}"
 
     return code
+
 
 async def execute_code_in_temp_file(language: str, code: str, timeout: int) -> tuple[str, str, int]:
     """Execute code in a temporary file and return stdout, stderr, and return code."""
@@ -173,27 +153,24 @@ async def execute_code_in_temp_file(language: str, code: str, timeout: int) -> t
         os.chdir(state.allowed_directory)
 
         # Write code to temp file
-        with open(temp_file, 'w') as f:
+        with open(temp_file, "w") as f:
             # Prepare and write code
             prepared_code = prepare_code(code, language)
             f.write(prepared_code)
             f.flush()
 
             # Prepare command
-            if language == 'rust':
+            if language == "rust":
                 # Special handling for Rust
-                output_path = 'temp_script.exe'
-                compile_cmd = ['rustc', temp_file, '-o', output_path]
+                output_path = "temp_script.exe"
+                compile_cmd = ["rustc", temp_file, "-o", output_path]
                 try:
-                    subprocess.run(compile_cmd,
-                                 check=True,
-                                 capture_output=True,
-                                 timeout=timeout)
+                    subprocess.run(compile_cmd, check=True, capture_output=True, timeout=timeout)
                     cmd = [output_path]
                 except subprocess.CalledProcessError as e:
-                    return '', e.stderr.decode(), e.returncode
+                    return "", e.stderr.decode(), e.returncode
             else:
-                cmd = config['command'] + [temp_file]
+                cmd = config["command"] + [temp_file]
 
             # Execute code
             try:
@@ -205,17 +182,18 @@ async def execute_code_in_temp_file(language: str, code: str, timeout: int) -> t
                 )
                 return result.stdout, result.stderr, result.returncode
             except subprocess.TimeoutExpired:
-                return '', f'Execution timed out after {timeout} seconds', 124
+                return "", f"Execution timed out after {timeout} seconds", 124
 
     finally:
         # Cleanup
         # Note: We stay in the allowed directory as all operations should happen there
         try:
             os.unlink(temp_file)
-            if language == 'rust' and os.path.exists(output_path):
+            if language == "rust" and os.path.exists(output_path):
                 os.unlink(output_path)
         except Exception:
             pass
+
 
 async def handle_execute_code(arguments: dict) -> List[types.TextContent]:
     """Handle code execution in various programming languages."""
@@ -230,12 +208,9 @@ async def handle_execute_code(arguments: dict) -> List[types.TextContent]:
         raise ValueError(f"Unsupported language: {language}")
 
     # Check if required command is available
-    command = LANGUAGE_CONFIGS[language]['command'][0]
+    command = LANGUAGE_CONFIGS[language]["command"][0]
     if not is_command_available(command):
-        return [types.TextContent(
-            type="text",
-            text=f"Error: {command} is not installed on the system"
-        )]
+        return [types.TextContent(type="text", text=f"Error: {command} is not installed on the system")]
 
     try:
         stdout, stderr, returncode = await execute_code_in_temp_file(language, code, timeout)
@@ -250,16 +225,11 @@ async def handle_execute_code(arguments: dict) -> List[types.TextContent]:
         if returncode != 0:
             result.append(f"\nProcess exited with code {returncode}")
 
-        return [types.TextContent(
-            type="text",
-            text="\n\n".join(result)
-        )]
+        return [types.TextContent(type="text", text="\n\n".join(result))]
 
     except Exception as e:
-        return [types.TextContent(
-            type="text",
-            text=f"Error executing code:\n{str(e)}"
-        )]
+        return [types.TextContent(type="text", text=f"Error executing code:\n{str(e)}")]
+
 
 async def execute_shell_script_in_temp_file(script: str, timeout: int) -> tuple[str, str, int]:
     """Execute a shell script in a temporary file and return stdout, stderr, and return code."""
@@ -270,7 +240,7 @@ async def execute_shell_script_in_temp_file(script: str, timeout: int) -> tuple[
         os.chdir(state.allowed_directory)
 
         # Write script to temp file
-        with open(temp_file, 'w') as f:
+        with open(temp_file, "w") as f:
             f.write("#!/bin/sh\n")  # Use sh for maximum compatibility
             f.write(script)
             f.flush()
@@ -280,15 +250,22 @@ async def execute_shell_script_in_temp_file(script: str, timeout: int) -> tuple[
 
         # Execute script
         try:
+            path_env = get_comprehensive_shell_paths()
+            env = os.environ.copy()
+            with open("tmp.txt", "a") as f:
+                f.write(path_env)
+            env["PATH"] = path_env
+            print(path_env)
             result = subprocess.run(
                 ["/bin/sh", temp_file],  # Use sh explicitly for consistent behavior
                 capture_output=True,
                 timeout=timeout,
                 text=True,
+                env=env,
             )
             return result.stdout, result.stderr, result.returncode
         except subprocess.TimeoutExpired:
-            return '', f'Execution timed out after {timeout} seconds', 124
+            return "", f"Execution timed out after {timeout} seconds", 124
 
     finally:
         # Cleanup
@@ -296,6 +273,7 @@ async def execute_shell_script_in_temp_file(script: str, timeout: int) -> tuple[
             os.unlink(temp_file)
         except Exception:
             pass
+
 
 async def handle_execute_shell_script(arguments: dict) -> List[types.TextContent]:
     """Handle shell script execution."""
@@ -314,13 +292,75 @@ async def handle_execute_shell_script(arguments: dict) -> List[types.TextContent
         if returncode != 0:
             result.append(f"\nScript exited with code {returncode}")
 
-        return [types.TextContent(
-            type="text",
-            text="\n\n".join(result)
-        )]
+        return [types.TextContent(type="text", text="\n\n".join(result))]
 
     except Exception as e:
-        return [types.TextContent(
-            type="text",
-            text=f"Error executing shell script:\n{str(e)}"
-        )]
+        return [types.TextContent(type="text", text=f"Error executing shell script:\n{str(e)}")]
+
+
+def get_comprehensive_shell_paths():
+    """
+    Get PATH from shells using login mode to capture initialization files
+    """
+    shells_file = Path("/etc/shells")
+
+    if not shells_file.exists():
+        return os.environ.get("PATH", "")
+
+    # Read available shells
+    try:
+        with open(shells_file, "r") as f:
+            shells = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    except IOError:
+        return os.environ.get("PATH", "")
+
+    all_paths = []
+
+    # Get PATH from each shell as login shell
+    for shell in shells:
+        if not os.path.exists(shell):
+            continue
+
+        # Different approaches for different shells
+        commands_to_try = [
+            [shell, "--login", "-i", "-c", "echo $PATH"],
+            [shell, "-l", "-i", "-c", "echo $PATH"],
+            [shell, "--login", "-c", "echo $PATH"],
+            [shell, "-l", "-c", "echo $PATH"],
+            [shell, "-c", "echo $PATH"],
+        ]
+
+        # Try each command until one works
+        for cmd in commands_to_try:
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                if result.returncode == 0 and result.stdout.strip():
+                    shell_path = result.stdout.strip()
+                    if shell_path and shell_path != "$PATH":
+                        all_paths.extend(shell_path.split(":"))
+                    break
+            except (subprocess.SubprocessError, subprocess.TimeoutExpired):
+                continue
+
+    # Add current PATH
+    current_path = os.environ.get("PATH", "")
+    if current_path:
+        all_paths.extend(current_path.split(":"))
+
+    # Remove duplicates while preserving order
+    return deduplicate_paths(all_paths)
+
+
+def deduplicate_paths(all_paths):
+    """
+    Remove duplicates while preserving order
+    """
+    seen = set()
+    merged_path = []
+    for path in all_paths:
+        path = path.strip()
+        if path and path not in seen and os.path.exists(path):
+            seen.add(path)
+            merged_path.append(path)
+
+    return ":".join(merged_path)


### PR DESCRIPTION
# Overview
`execute_shell_script` uses `/bin/sh` for executing command, which may not have correct `PATH` environment variable if user's machine is using other shell like `bash` or `zsh`, which are defined in there corresponding files like `.bashrc` or `.zshrc`

# Change
- Prepare the `PATH` env before executing the command. This is done by using each shell on the machine in interactive mode to get the `PATH` envs, then merge them together
- Also format file using `ruff`